### PR TITLE
Grs 118

### DIFF
--- a/lib/amplitude_api/config.rb
+++ b/lib/amplitude_api/config.rb
@@ -34,6 +34,7 @@ class AmplitudeAPI
           location_lat location_lng
           idfa idfv adid android_id
           event_id session_id
+          location_lat location_lng
         ]
       end
 

--- a/lib/amplitude_api/identification.rb
+++ b/lib/amplitude_api/identification.rb
@@ -13,14 +13,17 @@ class AmplitudeAPI
     #   @return [ String ] the user_properties to be attached to the Amplitude Identify
     attr_accessor :user_properties
 
+    attr_accessor :platform
+
     # Create a new Identification
     #
     # @param [ String ] user_id a user_id to associate with the identification
     # @param [ String ] device_id a device_id to associate with the identification
     # @param [ Hash ] user_properties various properties to attach to the user identification
-    def initialize(user_id: "", device_id: nil, user_properties: {})
+    def initialize(user_id: '', device_id: nil, platform: nil, user_properties: {})
       self.user_id = user_id
       self.device_id = device_id if device_id
+      self.platform = platform if platform
       self.user_properties = user_properties
     end
 
@@ -40,7 +43,10 @@ class AmplitudeAPI
       {
         user_id: user_id,
         user_properties: user_properties
-      }.tap { |hsh| hsh[:device_id] = device_id if device_id }
+      }.tap { |hsh|
+        hsh[:device_id] = device_id if device_id
+        hsh[:platform] = platform if platform
+      }
     end
 
     # @return [ true, false ]

--- a/spec/lib/amplitude_api/event_spec.rb
+++ b/spec/lib/amplitude_api/event_spec.rb
@@ -55,7 +55,9 @@ describe AmplitudeAPI::Event do
           "ip" => "127.0.0.1",
           "platform" => "Web",
           "country" => "United States",
-          "insert_id" => "bestId"
+          "insert_id" => "bestId",
+          "location_lat" => 16.88,
+          "location_lng" => 31.17
         )
 
         expect(event.to_hash).to eq(event_type: "sausage",
@@ -67,7 +69,9 @@ describe AmplitudeAPI::Event do
                                     ip: "127.0.0.1",
                                     platform: "Web",
                                     country: "United States",
-                                    insert_id: "bestId")
+                                    insert_id: "bestId",
+                                    location_lat: 16.88,
+                                    location_lng: 31.17)
       end
 
       it "accepts symbol attributes" do
@@ -82,7 +86,9 @@ describe AmplitudeAPI::Event do
           ip: "127.0.0.1",
           platform: "Web",
           country: "United States",
-          insert_id: "bestId"
+          insert_id: "bestId",
+          location_lat: 16.88,
+          location_lng: 31.17
         )
 
         expect(event.to_hash).to eq(event_type: "sausage",
@@ -94,7 +100,9 @@ describe AmplitudeAPI::Event do
                                     ip: "127.0.0.1",
                                     platform: "Web",
                                     country: "United States",
-                                    insert_id: "bestId")
+                                    insert_id: "bestId",
+                                    location_lat: 16.88,
+                                    location_lng: 31.17)
       end
     end
 
@@ -251,6 +259,44 @@ describe AmplitudeAPI::Event do
           event_type: "clicked on home"
         )
         expect(event.to_hash).not_to have_key(:country)
+      end
+    end
+
+    describe "location_lat" do
+      it "includes the location_lat for the event" do
+        event = described_class.new(
+          user_id: 123,
+          event_type: "clicked on home",
+          location_lat: 16.88
+        )
+        expect(event.to_hash[:location_lat]).to eq(16.88)
+      end
+
+      it "does not include the location_lat if it is not set" do
+        event = described_class.new(
+          user_id: 123,
+          event_type: "clicked on home"
+        )
+        expect(event.to_hash).not_to have_key(:location_lat)
+      end
+    end
+
+    describe "location_lng" do
+      it "includes the location_lng for the event" do
+        event = described_class.new(
+          user_id: 123,
+          event_type: "clicked on home",
+          location_lng: 31.17
+        )
+        expect(event.to_hash[:location_lng]).to eq(31.17)
+      end
+
+      it "does not include the location_lng if it is not set" do
+        event = described_class.new(
+          user_id: 123,
+          event_type: "clicked on home"
+        )
+        expect(event.to_hash).not_to have_key(:location_lng)
       end
     end
 

--- a/spec/lib/amplitude_api/identification_spec.rb
+++ b/spec/lib/amplitude_api/identification_spec.rb
@@ -43,6 +43,11 @@ describe AmplitudeAPI::Identification do
       expect(identification.to_hash[:device_id]).to eq("abc")
     end
 
+    it "includes the platform" do
+      identification = described_class.new(user_id: 123, device_id: "abc", platform: "iOS")
+      expect(identification.to_hash[:platform]).to eq("iOS")
+    end
+
     it "includes arbitrary user properties" do
       identification = described_class.new(
         user_id: 123,


### PR DESCRIPTION
## Context
Jira：[GRS-118](https://goodnight-app.atlassian.net/browse/GRS-118)
Rollbar：[#6050](https://rollbar.com/Goodnight/Goodnight-Rails/items/6050)

因升級 rails6 後，原本的 gem `amplitude-api` fork 版本太舊，套件 `typhoeus` 會噴一個 Faraday 的錯誤
查看後是裡面的 dependency gem `typhoeus` 太舊
將最新版 fork 回 organization，並且加上前人的 patch

origin patch commit 1： [Add location_lat & location_lng event props](https://github.com/harryuan65/amplitude-api/commit/2e2165bf4f9cb49b8b56a0e2d62996091b2efdc7) patch 在 https://github.com/Paktor/Goodnight-amplitude-api/commit/56c41f190c3d2154a12e5b9e38b4bed35dff1839
origin patch commit 2： [Add platform identification](https://github.com/harryuan65/amplitude-api/commit/b69220f5c548d8164203daf979cf86b9b639dd33) patch 在 https://github.com/Paktor/Goodnight-amplitude-api/commit/875b415eed95b06b0a35f3199037d36a5088bdf8
origin patch commit 3： [[Event] Add platform attributes](https://github.com/harryuan65/amplitude-api/commit/c9827d1a7cf348b56c9882f912b17d0be4eb472d) 官方更新在 https://github.com/toothrot/amplitude-api/commit/6a294cf7824ee196556bf58567f9b15b6a8276e0
origin patch commit 4： [change amplitude endpoint url](https://github.com/harryuan65/amplitude-api/commit/36b5ea82fbed1ee6458812d3cb24fd3d905b4a2b) 官方更新在 https://github.com/toothrot/amplitude-api/commit/19ff02258a488fc6e2f9b932e371d40bd71a2c5c

## File Changes
- lib/amplitude_api/config.rb
- lib/amplitude_api/identification.rb
- spec/lib/amplitude_api/event_spec.rb
- spec/lib/amplitude_api/identification_spec.rb

## Confirmation
n/a

### TestCases
- [x] rspec
![截圖 2022-07-13 下午12 33 47](https://user-images.githubusercontent.com/16208601/178651626-4fdc55a4-55f2-4cb7-9468-f975c97dcc62.png)

## Deployment/Risks
deploy to gn-api-env-2 after gemfile updated

## Notes
原本的 fork 版本
- [david's version](https://github.com/zetachang/amplitude-api)
- [harry's version](https://github.com/harryuan65/amplitude-api)

change log
- [faraday 1.0](https://github.com/lostisland/faraday/blob/main/UPGRADING.md#faraday-10)
  Removes sub-class constants definition from Faraday::Error

- [elasticsearch 7.6](https://github.com/elastic/elasticsearch-ruby/releases/tag/v7.6.0)
  This change is not compatible with [Typhoeus](https://github.com/typhoeus/typhoeus). The latest release is 1.3.1, but it's [still using the deprecated Faraday::Error namespace](https://github.com/typhoeus/typhoeus/blob/v1.3.1/lib/typhoeus/adapters/faraday.rb#L100). This has been fixed on master, but the last release was November 6, 2018. Version 1.4.0 should be ok once it's released.

### * elasticsearch-ruby 這個 gem 也要升，目前 elasticsearch-transport 版本 5.0.5 裡面還是舊的 faraday。AWS 上的 elasticsearch 的版本還是 5.3